### PR TITLE
Add more information regarding use of KEM background images

### DIFF
--- a/image-list-xml.html
+++ b/image-list-xml.html
@@ -213,6 +213,9 @@
             </tr>
           </tbody>
         </table>
+        <br>
+        <h2 id="BEKEM">BEKEM Background Images <a href="#BEKEM" title="Link">link</a></h2>
+        When a wallpaper-supported BEKEM or Key Expansion Module is enabled and attached to the phone, it will automatically use a cropped version of the background image specified in <code class="literal">List.xml</code> for the device. If a separate background image for the KEM module is desired, an different background image exclusively intended for the KEM module may be uploaded to the provisioning server. The image's file name must remain the same as the main background image displayed on the KEM module and must be sized and placed in its appropriate directory specified in the table above.
       </article>
     </main>
     <footer></footer>


### PR DESCRIPTION
Added another section with correct formatting and link regarding more information on appropriate instructions for adding background images for the KEM/BEKEM modules. Clarified the naming conventions of the background image file & how the default images may be displayed when a BEKEM-specific image is not specified.