### PR TITLE
add attribute to request client browser to open a new tab for links to external sites

### DIFF
--- a/as-feature-events.html
+++ b/as-feature-events.html
@@ -76,7 +76,7 @@
       </nav>
       <article>
         <h1>AS Feature Events</h1>
-        The patch also enables support for Do Not Disturb and Call Forward synchronization using Application Server Feature Events (<a href="https://ecma-international.org/publications-and-standards/standards/ecma-323/"><span class="icon">open_in_browser</span> ECMA-323</a>). Listed below are the per-vendor configuration options required.<br>
+        The patch also enables support for Do Not Disturb and Call Forward synchronization using Application Server Feature Events (<a href="https://ecma-international.org/publications-and-standards/standards/ecma-323/" target="_blank"><span class="icon">open_in_browser</span> ECMA-323</a>). Listed below are the per-vendor configuration options required.<br>
         <br>
         You do not need to make any changes in <a href="sip-conf.html">sip.conf</a> to enable this feature.<br>
         <br>

--- a/certificate-enrollment.html
+++ b/certificate-enrollment.html
@@ -90,7 +90,7 @@
           </tbody>
         </table>
         <br>
-        Using the Manufacturer Installed Certificate (MIC) to authenticate a phone does not require CAPF. Instead download and combine the <b>Cisco Root CA 2048 (crca2048)</b> and <b>Cisco Manufacturing CA (cmca2)</b> certificates available at <a href="https://www.cisco.com/security/pki/"><span class="icon">open_in_browser</span> https://www.cisco.com/security/pki</a> into a certificate chain.<br>
+        Using the Manufacturer Installed Certificate (MIC) to authenticate a phone does not require CAPF. Instead download and combine the <b>Cisco Root CA 2048 (crca2048)</b> and <b>Cisco Manufacturing CA (cmca2)</b> certificates available at <a href="https://www.cisco.com/security/pki/" target="_blank"><span class="icon">open_in_browser</span> https://www.cisco.com/security/pki</a> into a certificate chain.<br>
         <br>
         To enable use of CAPF set &lt;<code class="tag">processNodeName</code>&gt; and &lt;<code class="tag">phonePort</code>&gt; in <a href="sepmac-cnf-xml.html#capf/processNodeName">SEPMAC.cnf.xml</a> and include a certificate with the <code class="literal">CAPF</code> role in <code class="literal">ITLFile.tlv</code> or via the Trust Verification Service. An archive containing the server and client utilities can be downloaded from the URL below.<br>
         <br>

--- a/cgi-execute-xml.html
+++ b/cgi-execute-xml.html
@@ -81,7 +81,7 @@
         <br>
         If an &lt;<code class="tag">authenticationURL</code>&gt; has been defined, requests need to include a <code class="literal">Authorization</code> header encoded using the <code class="literal">basic</code> method. The username and password will be passed on to the authentication URL for checking. See <a href="phone-services-xml.html">Phone Services</a> for more information.<br>
         <br>
-        See the <a href="https://developer.cisco.com/site/ip-phone-services/overview/"><span class="icon">open_in_browser</span>  Cisco Unified IP Phone Services Application Development Notes</a> a list of URIs the each phone model supports.<br>
+        See the <a href="https://developer.cisco.com/site/ip-phone-services/overview/" target="_blank"><span class="icon">open_in_browser</span>  Cisco Unified IP Phone Services Application Development Notes</a> a list of URIs the each phone model supports.<br>
         <br>
         <code class="prettify lang-xml">&lt;CiscoIPPhoneExecute&gt;</code>
         <br>

--- a/documentation-overview.html
+++ b/documentation-overview.html
@@ -80,7 +80,7 @@
         <h1>Documentation Overview</h1>
         This documentation describes how to patch Asterisk to support Cisco SIP IP phones as well as how to configure the various features available on those devices. These IP phones require additional proprietary extensions to the SIP protocol to operate correctly and are only designed to operate with Cisco Unified Call Manager.<br>
         <br>
-        Questions may be sent to <a href="mailto:gareth.palmer3@gmail.com"><span class="icon">mail</span> gareth.palmer3@gmail.com</a>. Source code for the project (patch, utilities and documentation) is also available on <a href="https://github.com/usecallmanagernz"><span class="icon">open_in_browser</span> GitHub</a>.<br>
+        Questions may be sent to <a href="mailto:gareth.palmer3@gmail.com"><span class="icon">mail</span> gareth.palmer3@gmail.com</a>. Source code for the project (patch, utilities and documentation) is also available on <a href="https://github.com/usecallmanagernz" target="_blank"><span class="icon">open_in_browser</span> GitHub</a>.<br>
         <br>
         <div class="horizontal-rule"></div>
         The patch provides the following features required by the Cisco IP phones that are not available in standard Asterisk.<br>

--- a/freepbx-integration.html
+++ b/freepbx-integration.html
@@ -76,11 +76,11 @@
       </nav>
       <article>
         <h1>FreePBX Integration</h1>
-        The examples shown on this site are for an Asterisk install that uses the default configuration files. If you are using FreePBX <a href="https://www.freepbx.org"><span class="icon">open_in_browser</span> www.freepbx.org</a> to provision Cisco phones then you will need to perform additional steps to apply the device specific configuration options.<br>
+        The examples shown on this site are for an Asterisk install that uses the default configuration files. If you are using FreePBX <a href="https://www.freepbx.org" target="_blank"><span class="icon">open_in_browser</span> www.freepbx.org</a> to provision Cisco phones then you will need to perform additional steps to apply the device specific configuration options.<br>
         <br>
         Listed below are external guides created by other people that may be useful.<br>
         <br>
-        <a href="https://sangomakb.atlassian.net/wiki/spaces/FP/pages/11862323/Patching+Asterisk+11+for+Cisco+phones"><span class="icon">open_in_browser</span> FreePBX Wiki</a> has a slightly outdated guide on how to patch Asterisk 11 and also has some examples of the additional configuration needed.
+        <a href="https://sangomakb.atlassian.net/wiki/spaces/FP/pages/11862323/Patching+Asterisk+11+for+Cisco+phones" target="_blank"><span class="icon">open_in_browser</span> FreePBX Wiki</a> has a slightly outdated guide on how to patch Asterisk 11 and also has some examples of the additional configuration needed.
       </article>
     </main>
     <footer>

--- a/itl-file-tlv.html
+++ b/itl-file-tlv.html
@@ -161,7 +161,7 @@
         <b>5.</b> Enable SIP-TLS mode by setting &lt;<code class="tag">transportLayerProtocol</code>&gt; to <code class="literal">3</code> and setting &lt;<code class="tag">deviceSecurityMode</code>&gt; to either <code class="literal">2</code> (Authenticated) or <code class="literal">3</code> (Encrypted) in <a href="sepmac-cnf-xml.html">SEPMAC.cnf.xml</a>. Optionally, any XML services can be configured to use HTTPS.<br>
         <br>
         <h2 id="libsrtp">libsrtp <a href="#libsrtp" title="Link">link</a></h2>
-        To use secure (encrypted) RTP <code class="literal">libsrtp</code> must be installed. The latest release is available from the <a href="https://github.com/cisco/libsrtp/releases"><span class="icon">open_in_browser</span> libsrtp GitHub repository</a>.<br>
+        To use secure (encrypted) RTP <code class="literal">libsrtp</code> must be installed. The latest release is available from the <a href="https://github.com/cisco/libsrtp/releases" target="_blank"><span class="icon">open_in_browser</span> libsrtp GitHub repository</a>.<br>
         <br>
         <code class="command-line"><span class="prompt">~/libsrtp-X.X.X$</span> ./configure --prefix=/usr --enable-openssl
 <span class="prompt">~/libsrtp-X.X.X$</span> make shared_library

--- a/load-information.html
+++ b/load-information.html
@@ -75,7 +75,7 @@
       </nav>
       <article>
         <h1>Firmware Load Information</h1>
-        The firmware downloaded by the phone from the provisioning server is specified by &lt;<code class="tag">loadInformation</code>&gt; in <a href="sepmac-cnf-xml.html#loadInformation">SEPMAC.cnf.xml</a> without the <code class="literal">.loads</code> suffix. To download firmware updates you will first need to register for a login (free, at the time of writing) at <a href="https://www.cisco.com"><span class="icon">open_in_browser</span> www.cisco.com</a>. Firmware updates are selected via the <b>Session Initiation Protocol (SIP) Software</b> link when downloading software.<br>
+        The firmware downloaded by the phone from the provisioning server is specified by &lt;<code class="tag">loadInformation</code>&gt; in <a href="sepmac-cnf-xml.html#loadInformation">SEPMAC.cnf.xml</a> without the <code class="literal">.loads</code> suffix. To download firmware updates you will first need to register for a login (free, at the time of writing) at <a href="https://www.cisco.com" target="_blank"><span class="icon">open_in_browser</span> www.cisco.com</a>. Firmware updates are selected via the <b>Session Initiation Protocol (SIP) Software</b> link when downloading software.<br>
         <br>
         To convert firmware packages from <code class="literal">.cop.sgn</code> or <code class="literal">.cop.sha512</code> to <code class="literal">.tar.gz</code> use the <code class="literal">stripsgn</code> script.<br>
         <br>

--- a/network-locale.html
+++ b/network-locale.html
@@ -75,7 +75,7 @@
       </nav>
       <article>
         <h1>Network Locale</h1>
-        The Network locales allows the phone to play tones (ringing, busy etc.) native to the phone's country. To download locale packages you will first need to register for a login (free, at the time of writing) at <a href="https://www.cisco.com"><span class="icon">open_in_browser</span> www.cisco.com</a>. Locale packages are selected from the <b>Unified Communications Manager Endpoints Locale Installer</b> link when downloading software.<br>
+        The Network locales allows the phone to play tones (ringing, busy etc.) native to the phone's country. To download locale packages you will first need to register for a login (free, at the time of writing) at <a href="https://www.cisco.com" target="_blank"><span class="icon">open_in_browser</span> www.cisco.com</a>. Locale packages are selected from the <b>Unified Communications Manager Endpoints Locale Installer</b> link when downloading software.<br>
         <br>
         The combined network locale package is named <code class="literal">po-locale-combined_network-<i>VERSION</i>.cop.sgn</code> or <code class="literal">.cop.sha512</code>, it contains the locales for every supported region. The name of the directory to download the network locale <code class="literal">.xml</code> file from in specified by &lt;<code class="tag">name</code>&gt; inside &lt;<code class="tag">networkLocaleInfo</code>&gt; in <a href="sepmac-cnf-xml.html#networkLocale/name">SEPMAC.cnf.xml</a>.<br>
         <br>

--- a/patching-asterisk.html
+++ b/patching-asterisk.html
@@ -87,7 +87,7 @@
         <br>
         <b>2.</b> Download the version of Asterisk that matches the version number in the name of the patch.<br>
         <br>
-        <a href="https://asterisk.org/downloads"><span class="icon">open_in_browser</span> Asterisk Downloads</a>.<br>
+        <a href="https://asterisk.org/downloads" target="_blank"><span class="icon">open_in_browser</span> Asterisk Downloads</a>.<br>
         <br>
         <b>3.</b> Extract the archive and apply the patch.<br>
         <br>

--- a/phone-services-xml.html
+++ b/phone-services-xml.html
@@ -79,7 +79,7 @@
         <br>
         <a href="https://github.com/usecallmanagernz/services/archive/v2.6.tar.gz" download><span class="icon">file_download</span> services-2.6.tar.gz</a> (17K) <span class="icon">event</span> 14/05/2024 <span class="icon">security</span> SHA256:bef0136a098e73b5ad2319e329d5a9a78f8d3c4c6766b3f5b8fadb215ba08ed0.<br>
         <br>
-        See <a href="https://developer.cisco.com/site/ip-phone-services/overview/"><span class="icon">open_in_browser</span> Cisco Unified IP Phone Services Application Development Notes</a> for a list of XML objects the each phone model supports.<br>
+        See <a href="https://developer.cisco.com/site/ip-phone-services/overview/" target="_blank"><span class="icon">open_in_browser</span> Cisco Unified IP Phone Services Application Development Notes</a> for a list of XML objects the each phone model supports.<br>
         <br>
         <h2 id="authenticationURL">authenticationURL <a href="#authenticationURL" title="Link">link</a></h2>
         If defined, the phone will make requests to this URL containing the username and password that was included in the <code class="literal">Authorization</code> header in the request to <b>http://<i>x.x.x.x</i>/CGI/Execute</b>. The script handling the request must respond exactly with <code class="literal">AUTHORIZED</code> (with no newline character at end) otherwise the request will be denied. See <a href="cgi-execute-xml.html">CGI Execute</a> for more information.<br>

--- a/user-locale.html
+++ b/user-locale.html
@@ -75,7 +75,7 @@
       </nav>
       <article>
         <h1>User Locale</h1>
-        The user locale allows the phone to display text (menu items, soft keys etc.) native to the phone's language. To download locale packages you will first need to register for a login (free, at the time of writing) at <a href="https://www.cisco.com"><span class="icon">open_in_browser</span> www.cisco.com</a>. Locale packages are selected from the <b>Unified Communications Manager Endpoints Locale Installer</b> link when downloading software.<br>
+        The user locale allows the phone to display text (menu items, soft keys etc.) native to the phone's language. To download locale packages you will first need to register for a login (free, at the time of writing) at <a href="https://www.cisco.com" target="_blank"><span class="icon">open_in_browser</span> www.cisco.com</a>. Locale packages are selected from the <b>Unified Communications Manager Endpoints Locale Installer</b> link when downloading software.<br>
         <br>
         The user locale package is named <code class="literal">po-locale-<i>LANGUAGE</i>-<i>VERSION</i>.cop.sgn</code> or <code class="literal">.cop.sha512</code>, the <code class="literal">LANGUAGE</code> is the ISO code for your region, eg: <code class="literal">en_GB</code> is English (United Kingdom). The name of the directory to download the user locale <code class="literal">.jar</code> file from is specified by &lt;<code class="tag">name</code>&gt; inside &lt;<code class="tag">userLocale</code>&gt; in <a href="sepmac-cnf-xml.html#userLocale/name">SEPMAC.cnf.xml</a>.<br>
         <br>

--- a/vpn-group.html
+++ b/vpn-group.html
@@ -81,7 +81,7 @@
         <br>
         <b>1.</b> Download a version of OpenConnect that is <code class="literal">1.2.0</code> or newer.<br>
         <br>
-        <a href="https://ocserv.gitlab.io/www/download.html"><span class="icon">open_in_browser</span> OpenConnect VPN Server Downloads</a>.<br>
+        <a href="https://ocserv.gitlab.io/www/download.html" target="_blank"><span class="icon">open_in_browser</span> OpenConnect VPN Server Downloads</a>.<br>
         <br>
         <b>2.</b> Extract the archive.<br>
         <br>


### PR DESCRIPTION
the `target="_blank"` attribute on links requests the user's browser to open a new tab/window. This is still subject to user's browser settings. 
Adding this tag on links to external sites is consistent with behaviour of documentation and other sites across the internet.