### PR TITLE
Fix minor typo in dialTemplate section

### DIFF
--- a/sepmac-cnf-xml.html
+++ b/sepmac-cnf-xml.html
@@ -1057,7 +1057,7 @@
     &lt;ringSettingBusyStationPolicy&gt;0&lt;/ringSettingBusyStationPolicy&gt;</code>
         <br>
         <h2 id="dialTemplate">dialTemplate <a href="#dialTemplate" title="Link">link</a></h2>
-        Name of the file containing the digit timeout patterns. See <a href="dial-template-xml.html">Dial Templates</a> for further information. <b>Note</b>: default timeout is 15 seconds if you don not specify a dial template.<br>
+        Name of the file containing the digit timeout patterns. See <a href="dial-template-xml.html">Dial Templates</a> for further information. <b>Note</b>: default timeout is 15 seconds if you do not specify a dial template.<br>
         <br>
         <code class="prettify lang-xml">    &lt;dialTemplate&gt;<i>DIAL TEMPLATE FILE</i>&lt;/dialTemplate&gt;</code>
         <br>


### PR DESCRIPTION
Corrected minor typo "don not" to "do not" in dialTemplate section of ``sepmac-cnf-xml.html``